### PR TITLE
add missing 'plsdepot.R' in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,3 +45,4 @@ Collate:
     'simplsca.R'
     'plot.simpls.R'
     'plot.simplsca.R'
+    'plsdepot.R'


### PR DESCRIPTION
When trying to install the package using
install_github("gastonstat/plsdepot")

DESCRIPTION file is missing 'plsdepot.R'

This avoids the package from being installed
I have added the missing line and successfully installed in R (4.2.1)

